### PR TITLE
Fix Render build script for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,12 @@
     "server"
   ],
   "scripts": {
-    "dev": "concurrently \"npm run dev --workspace server\" \"npm run dev --workspace client\"",
-    "build": "npm run build --workspace client && npm run build --workspace server",
-    "start": "npm run start --workspace server",
-    "lint": "npm run lint --workspace client && npm run lint --workspace server",
-    "client:build": "npm run build --workspace client",
-    "client:dev": "npm run dev --workspace client",
-    "server": "npm run start --workspace server",
-    "server:dev": "npm run dev --workspace server",
-    "render-build": "npm install && npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "build": "cd client && npm install && npm run build && cd ../server && npm install",
+  "start": "node server/index.js",
+  "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\"",
+  "client:dev": "npm run dev --prefix client",
+  "server:dev": "npm run dev --prefix server"
+},
   "devDependencies": {
     "concurrently": "^8.2.2"
   },


### PR DESCRIPTION
changed this in root package.json, Render fails: it doesn’t support --workspace.

```
"scripts": {
  "build": "cd client && npm install && npm run build && cd ../server && npm install",
  "start": "node server/index.js",
  "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\"",
  "client:dev": "npm run dev --prefix client",
  "server:dev": "npm run dev --prefix server"
},
```