### PR TITLE
Hide modal close (×) button while editing trip

### DIFF
--- a/client/src/pages/Profile.css
+++ b/client/src/pages/Profile.css
@@ -218,6 +218,111 @@
   color: #D3D3D3;
 }
 
+.modal-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.edit-btn,
+.delete-btn {
+  padding: 10px 18px;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.2s ease-in-out;
+}
+
+.edit-btn {
+  background-color: #49c5b6;
+  color: #ffffff;
+}
+
+.delete-btn {
+  background-color: #ff5e5e;
+  color: #ffffff;
+}
+
+.edit-btn:hover {
+  background-color: #3db3a5;
+}
+
+.delete-btn:hover {
+  background-color: #e04c4c;
+}
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  align-items: center;
+}
+/* Add this container to align Save/Cancel side-by-side */
+.edit-form .button-group {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.edit-form input,
+.edit-form textarea {
+  width: 90%;
+  padding: 0.6rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  resize: vertical;
+}
+
+.edit-form .button-group {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+/* Style the buttons */
+.edit-form .edit-btn,
+.edit-form .cancel-btn {
+  width: 100px;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 10px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.edit-form .edit-btn {
+  background-color: #49c5b6;
+  color: white;
+}
+
+.edit-form .edit-btn:hover {
+  background-color: #3db3a5;
+}
+
+.edit-form .cancel-btn {
+  background-color: #888;
+  color: white;
+}
+
+.edit-form .cancel-btn:hover {
+  background-color: #666;
+}
+
+/* .edit-form .edit-btn,
+.edit-form .cancel-btn {
+  width: 100px;
+  font-size: 15px;
+} */
+
+/* Footer Start here */
 .footer {
   text-align: center;
   padding: 2rem 1rem 1rem;

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,17 +1,28 @@
 import React, { useState, useEffect } from 'react';
 import './Profile.css';
 import Navbar from '../components/Navbar';
-import { useQuery } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client';
 import { GET_ME } from '../utils/queries';
+import { DELETE_TRAVEL_PLAN, UPDATE_TRAVEL_PLAN } from '../utils/mutations';
 import { useNavigate, Link } from 'react-router-dom'; // ✅ ADDED Link for profile
+
+
 
 const Profile = () => {
   const [selectedTrip, setSelectedTrip] = useState(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editForm, setEditForm] = useState({ title: '', notes: '' });
   const navigate = useNavigate();
-  
   // Add useQuery(GET_ME) to get real logged-in user
   //✅  Fetch logged-in user data, including their travel plans
   const { loading, data } = useQuery(GET_ME);
+  const [deleteTravelPlan] = useMutation(DELETE_TRAVEL_PLAN, {
+    refetchQueries: [{ query: GET_ME }],
+  });
+
+  const [updateTravelPlan] = useMutation(UPDATE_TRAVEL_PLAN, {
+    refetchQueries: [{ query: GET_ME }],
+  });
 
   useEffect(() => {
     if (!loading && !data?.me) {
@@ -36,6 +47,28 @@ const Profile = () => {
   
   const user = data.me;
   const trips = user.travelPlans || [];
+
+  const handleDelete = async () => {
+    await deleteTravelPlan({ variables: { id: selectedTrip._id } });
+    setSelectedTrip(null);
+  };
+
+  const handleEditToggle = () => {
+    setEditForm({ title: selectedTrip.title, notes: selectedTrip.notes });
+    setIsEditing(true);
+  };
+
+  const handleEditSave = async () => {
+    await updateTravelPlan({
+      variables: {
+        id: selectedTrip._id,
+        title: editForm.title,
+        notes: editForm.notes,
+      },
+    });
+    setSelectedTrip(null);
+    setIsEditing(false);
+  };
   
   if (trips.length === 0) {
     return (
@@ -96,40 +129,66 @@ const Profile = () => {
 
       {/* Modal */}
       {selectedTrip && (
-     <div className="modal-overlay" onClick={() => setSelectedTrip(null)}>
-       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-         <button className="close-btn" onClick={() => setSelectedTrip(null)}>×</button>
+        <div className="modal-overlay" onClick={() => setSelectedTrip(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+          {!isEditing && (
+            <button className="close-btn" onClick={() => setSelectedTrip(null)}>×</button>
+          )}
+            {/* ✅ Dynamic image logic based on index */}
+            <img
+              src={`/default-trip-${trips.indexOf(selectedTrip) % 7 + 1}.jpg`}
+              alt={selectedTrip.title}
+              className="modal-image"
+              onError={(e) => {
+                e.target.onerror = null;
+                e.target.src = '/default-trip-fallback.jpg';
+              }}
+            />
 
-         {/* ✅ Dynamic image logic based on index */}
-         <img
-         src={`/default-trip-${trips.indexOf(selectedTrip) % 7 + 1}.jpg`}
-         alt={selectedTrip.title}
-         className="modal-image"
-        onError={(e) => {
-        e.target.onerror = null;
-        e.target.src = '/default-trip-fallback.jpg';
-        }}
-        />
+            {!isEditing ? (
+              <>
+                <h2>{selectedTrip.title}</h2>
+                <p className="trip-date">{selectedTrip.startDate} – {selectedTrip.endDate}</p>
+                <p>{selectedTrip.notes}</p>
+                 {/* ✅ Show details of destinations and activities */}
+                {selectedTrip.destinations?.map((dest, idx) => (
+                  <div key={idx}>
+                    <h4>{dest.name}, {dest.location}</h4>
+                    <p>{dest.arrivalDate} – {dest.departureDate}</p>
+                    <ul className="trip-details-list">
+                      {dest.activities?.map((activity, aIdx) => (
+                        <li key={aIdx}>– {activity}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
 
-       <h2>{selectedTrip.title}</h2>
-       <p className="trip-date">{selectedTrip.startDate} – {selectedTrip.endDate}</p>
-       <p>{selectedTrip.notes}</p>
-
-       {/* ✅ Show details of destinations and activities */}
-       {selectedTrip.destinations?.map((dest, idx) => (
-        <div key={idx}>
-          <h4>{dest.name}, {dest.location}</h4>
-          <p>{dest.arrivalDate} – {dest.departureDate}</p>
-          <ul className="trip-details-list">
-            {dest.activities?.map((activity, aIdx) => (
-              <li key={aIdx}>– {activity}</li>
-            ))}
-          </ul>
+                <div className="modal-actions">
+                  <button className="edit-btn" onClick={handleEditToggle}>Edit</button>
+                  <button className="delete-btn" onClick={handleDelete}>Delete</button>
+                </div>
+              </>
+            ) : (
+              <div className="edit-form">
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+                />
+                <textarea
+                  rows="3"
+                  value={editForm.notes}
+                  onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                />
+                <div className="button-group">
+                  <button className="edit-btn" onClick={handleEditSave}>Save</button>
+                  <button className="cancel-btn" onClick={() => setIsEditing(false)}>Cancel</button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
-       ))}
-      </div>
-     </div>
-    )}
+      )}
 
       <footer className="footer">
         <p>© 2025 TripMate. All rights reserved.</p>

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -58,3 +58,44 @@ export const ADD_TRIP = gql`
     }
   }
 `;
+
+export const DELETE_TRAVEL_PLAN = gql`
+  mutation DeleteTravelPlan($id: ID!) {
+    deleteTravelPlan(id: $id) {
+      _id
+    }
+  }
+`;
+
+export const UPDATE_TRAVEL_PLAN = gql`
+  mutation UpdateTravelPlan(
+    $id: ID!
+    $title: String
+    $startDate: String
+    $endDate: String
+    $notes: String
+    $destinations: [DestinationInput]
+  ) {
+    updateTravelPlan(
+      id: $id
+      title: $title
+      startDate: $startDate
+      endDate: $endDate
+      notes: $notes
+      destinations: $destinations
+    ) {
+      _id
+      title
+      startDate
+      endDate
+      notes
+      destinations {
+        name
+        location
+        arrivalDate
+        departureDate
+        activities
+      }
+    }
+  }
+`;


### PR DESCRIPTION
✅ Implemented Edit and Delete buttons in Trip Modal (Profile page)

✅ Added mutation handling for updateTravelPlan and deleteTravelPlan

✅ Created edit form with prefilled trip title and notes

✅ Styled Save/Cancel buttons and aligned them horizontally

✅ Hid close (×) button while editing to avoid user confusion

✅ Ensured modal reverts to view mode on Cancel or after Save

✅ Verified full functionality: edit updates trip, delete removes it, view displays correct data

video :

https://github.com/user-attachments/assets/db0de2e8-6ef0-4bdf-8269-218fe691c000

